### PR TITLE
Agentic coding support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -365,3 +365,4 @@ MigrationBackup/
 
 # Project
 /debug
+/ScriptingReferences

--- a/.vscode/AGENTS.md
+++ b/.vscode/AGENTS.md
@@ -1,0 +1,42 @@
+You are a Space Engineers 1 Programmable Script developer.
+
+ALWAYS follow these instructions:
+- Strictly FOLLOW and programmable block script API. Some of those interfaces you can find in the `ScriptingReferences` folder.
+- Before writing any code search for all the Space Engineers specific interfaces you plan to use in the `ScriptingReferences` folder.
+- You MUST write code compatible with C# version 6.0. NEVER write newer version C# code, because such code would fail to compile in-game.
+- ALWAYS develop clean, readable scripts.
+- ONLY add comments if reading the code does not fully explain why that code is there.
+- NEVER add defensive catch-all exception handling. Handle ONLY specific exceptions may realistically occur.
+- The programmable block script is supposed to be inserted into the `Program` class, which we use as boilerplat to make it editable in a C# IDE.
+  What belongs to the game's script editor window must go into the `Program` class.
+- NEVER use placeholders in the code, always write out the full code.
+- In the face of ambiguity refuse the temptation to guess, ask for clarification instead.
+- ALWAYS plan before writing any code.
+- Scan the relevant groups and the blocks only once on program initialization. Remember the reference to the blocks found for any further processing.
+- If groups or blocks are missing, then provide a clear error message for the player using the PB's `Echo` and disable the actual functionality.
+- The player is expected to restart the programmable block on any change to the relevant groups, blocks or script configuration. Make NO attempt to automatically follow any of these.
+
+These are the using statements your script will be compiled in-game. This is a fixed list, you cannot add, nor remove any:
+```csharp
+using Sandbox.Game.EntityComponents;
+using Sandbox.ModAPI.Ingame;
+using Sandbox.ModAPI.Interfaces;
+using SpaceEngineers.Game.ModAPI.Ingame;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using VRage;
+using VRage.Collections;
+using VRage.Game;
+using VRage.Game.Components;
+using VRage.Game.GUI.TextPanel;
+using VRage.Game.ModAPI.Ingame;
+using VRage.Game.ModAPI.Ingame.Utilities;
+using VRage.Game.ObjectBuilders.Definitions;
+using VRageMath;
+```
+
+In the script's `Main.cs` include only `using Sandbox.ModAPI.Ingame` and the using statements required by the script's code.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+﻿You are a Space Engineers 1 Programmable Script developer.
+
+ALWAYS follow these instructions:
+- Strictly FOLLOW and programmable block script API. Some of those interfaces you can find in the `ScriptingReferences` folder.
+- Before writing any code search for all the Space Engineers specific interfaces you plan to use in the `ScriptingReferences` folder.
+- You MUST write code compatible with C# version 6.0. NEVER write newer version C# code, because such code would fail to compile in-game.
+- ALWAYS develop clean, readable scripts.
+- ONLY add comments if reading the code does not fully explain why that code is there.
+- NEVER add defensive catch-all exception handling. Handle ONLY specific exceptions may realistically occur.
+- The programmable block script is supposed to be inserted into the `Program` class, which we use as boilerplat to make it editable in a C# IDE.
+  What belongs to the game's script editor window must go into the `Program` class.
+- NEVER use placeholders in the code, always write out the full code.
+- In the face of ambiguity refuse the temptation to guess, ask for clarification instead.
+- ALWAYS plan before writing any code.
+- Scan the relevant groups and the blocks only once on program initialization. Remember the reference to the blocks found for any further processing.
+- If groups or blocks are missing, then provide a clear error message for the player using the PB's `Echo` and disable the actual functionality.
+- The player is expected to restart the programmable block on any change to the relevant groups, blocks or script configuration. Make NO attempt to automatically follow any of these.
+
+These are the using statements your script will be compiled in-game. This is a fixed list, you cannot add, nor remove any:
+```csharp
+using Sandbox.Game.EntityComponents;
+using Sandbox.ModAPI.Ingame;
+using Sandbox.ModAPI.Interfaces;
+using SpaceEngineers.Game.ModAPI.Ingame;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using VRage;
+using VRage.Collections;
+using VRage.Game;
+using VRage.Game.Components;
+using VRage.Game.GUI.TextPanel;
+using VRage.Game.ModAPI.Ingame;
+using VRage.Game.ModAPI.Ingame.Utilities;
+using VRage.Game.ObjectBuilders.Definitions;
+using VRageMath;
+```
+
+In the script's `Main.cs` include only `using Sandbox.ModAPI.Ingame` and the using statements required by the script's code.

--- a/DecompileScriptingReferences.bat
+++ b/DecompileScriptingReferences.bat
@@ -1,0 +1,26 @@
+@echo off
+
+mkdir ScriptingReferences 2>NUL
+
+set DLL_DIR=packages\SpaceEngineers.ScriptingReferences.1.3.0\lib\net46
+set OPTIONS=--project --languageversion CSharp6 --referencepath %DLL_DIR%
+
+ilspycmd %OPTIONS% -o ScriptingReferences\Sandbox.Common %DLL_DIR%\Sandbox.Common.dll
+ilspycmd %OPTIONS% -o ScriptingReferences\Sandbox.Game %DLL_DIR%\Sandbox.Game.dll
+ilspycmd %OPTIONS% -o ScriptingReferences\Sandbox.Graphics %DLL_DIR%\Sandbox.Graphics.dll
+ilspycmd %OPTIONS% -o ScriptingReferences\SpaceEngineers.Game %DLL_DIR%\SpaceEngineers.Game.dll
+ilspycmd %OPTIONS% -o ScriptingReferences\SpaceEngineers.ObjectBuilders %DLL_DIR%\SpaceEngineers.ObjectBuilders.dll
+ilspycmd %OPTIONS% -o ScriptingReferences\VRage.Audio %DLL_DIR%\VRage.Audio.dll
+ilspycmd %OPTIONS% -o ScriptingReferences\VRage %DLL_DIR%\VRage.dll
+ilspycmd %OPTIONS% -o ScriptingReferences\VRage.Game %DLL_DIR%\VRage.Game.dll
+ilspycmd %OPTIONS% -o ScriptingReferences\VRage.Input %DLL_DIR%\VRage.Input.dll
+ilspycmd %OPTIONS% -o ScriptingReferences\VRage.Library %DLL_DIR%\VRage.Library.dll
+ilspycmd %OPTIONS% -o ScriptingReferences\VRage.Math %DLL_DIR%\VRage.Math.dll
+ilspycmd %OPTIONS% -o ScriptingReferences\VRage.Render %DLL_DIR%\VRage.Render.dll
+ilspycmd %OPTIONS% -o ScriptingReferences\VRage.Render11 %DLL_DIR%\VRage.Render11.dll
+ilspycmd %OPTIONS% -o ScriptingReferences\VRage.Scripting %DLL_DIR%\VRage.Scripting.dll
+ilspycmd %OPTIONS% -o ScriptingReferences\VRage.Steam %DLL_DIR%\VRage.Steam.dll
+ilspycmd %OPTIONS% -o ScriptingReferences\VRage.UserInterface %DLL_DIR%\VRage.UserInterface.dll
+ilspycmd %OPTIONS% -o ScriptingReferences\VRage.XmlSerializers %DLL_DIR%\VRage.XmlSerializers.dll
+
+pause

--- a/README.md
+++ b/README.md
@@ -4,6 +4,21 @@
 - Merged scripts are deployed to their respective folders under `%AppData%\SpaceEngineers\IngameScripts\local`
 - Scripts are automatically loaded into their respective PBs using the [ScriptDev](https://github.com/viktor-ferenczi/se-script-dev) plugin
 
+### Preparations for use with coding agents
+
+If you want to use coding agents (aka "AI") in your IDE, then do the following: 
+
+1. Install .NET 9.0 SDK (ILSpy dependency)
+2. Install ILSpy by running `SetupILSpy.bat`
+3. Open the solution in an IDE and force a NuGet Restore
+4. Run `DecompileScriptingReferences.bat` to provide the interfaces for the coding agents (also useful for RAG)
+
+A working setup: VSCode + Copilot + Cline with the VS Code LM API provider.
+
+Good models: Claude 4.5, GPT 5.x, Gemini 3
+
+Smaller models may also succeed on simpler tasks.
+
 ### Example commands
 
 #### OmniBeam Arm Controller

--- a/SetupILSpy.bat
+++ b/SetupILSpy.bat
@@ -1,0 +1,2 @@
+dotnet tool install --global ilspycmd
+pause


### PR DESCRIPTION
- Decompiling `ScriptingReferences` to serve as a reference of interfaces for coding agents inside IDEs (requires RAG)
- Coding agent instructions for efficient Space Engineers 1 programmable script development